### PR TITLE
Use key4hep image for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       # Checkout code
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR changes the CI config from using an [LCG release](https://github.com/AIDASoft/run-lcg-view) on top of the [cmvfs github action](https://github.com/cvmfs-contrib/github-action-cvmfs) to using the [key4hep images ](https://github.com/key4hep/key4hep-images) (specifically alma9 without cvmfs installation) together with the cvmfs github action. Once we integrate FastCaloSim the LCG release on top will cause issues, so we'll just pick the additional packages we need from cvmfs.

Some considerations: 

In principle it would be nice to just use the key4hep images that already have cvmfs installed as:
```bash
runs-on: ubuntu-24.04
container: ghcr.io/key4hep/key4hep-images/alma9-cvmfs:latest
options: >-
	--device=/dev/fuse
	--cap-add=SYS_ADMIN
```
but it seems like the automounting  of these images is not properly configured so that we don't get access to cvfms like that. Furthermore, we can't use the `container:` tag as we need to run the github action cvmfs step before starting the container which is not natively supported by github. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration
	- Simplified CI job setup
	- Removed unnecessary environment variables
	- Transitioned to Ubuntu 22.04 for workflow execution
	- Renamed steps for clarity in the CI process
	- Added a new environment variable for containerization
	- Included a new step for uploading artifacts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->