### PR TITLE
Add FastCaloSim as dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(lwtnn_ROOT "/cvmfs/sft.cern.ch/lcg/views/LCG_106/x86_64-el9-gcc13-opt"
 FetchContent_Declare(
   FastCaloSim
   GIT_REPOSITORY https://github.com/fcs-proj/FastCaloSim.git
-  GIT_TAG v0.4.0-alpha
+  GIT_TAG v0.5.0-alpha
   GIT_PROGRESS TRUE
   CMAKE_ARGS
   -DCMAKE_BUILD_TYPE=Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Setup the project
 cmake_minimum_required(VERSION 3.30)
 
@@ -14,29 +14,53 @@ include(cmake/spell-targets.cmake)
 
 message(STATUS "Configuring project ${PROJECT_NAME}")
 
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Configure C++ Standard
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to use")
+
 # Ensure the standard is strictly required
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Disable compiler-specific extensions
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Find required packages
 find_package(Geant4 REQUIRED)
 find_package(DD4hep REQUIRED COMPONENTS DDG4 DDParsers DDCore DDDetectors)
+
+# ----------------------------FastCaloSim-------------------------------------
+include(FetchContent)
+
+# LWTNN is not shipped by DD4hep but a dependency of FastCaloSim
+# We'll give FastCaloSim a hint where to find it
+set(lwtnn_ROOT "/cvmfs/sft.cern.ch/lcg/views/LCG_106/x86_64-el9-gcc13-opt"
+  CACHE PATH "Where to find lwtnn" FORCE
+)
+FetchContent_Declare(
+  FastCaloSim
+  GIT_REPOSITORY https://github.com/fcs-proj/FastCaloSim.git
+  GIT_TAG v0.4.0-alpha
+  GIT_PROGRESS TRUE
+  CMAKE_ARGS
+  -DCMAKE_BUILD_TYPE=Debug
+  -DCMAKE_CXX_FLAGS="-g -Wall -Wextra"
+  -DCMAKE_CXX_FLAGS_DEBUG="-O0 -g3 -DDEBUG"
+  -DFastCaloSim_DEVELOPER_MODE=ON
+)
+
+FetchContent_MakeAvailable(FastCaloSim)
 
 # Enable RPATH and set compiler flags for DD4hep
 set(DD4HEP_SET_RPATH ON)
 dd4hep_set_compiler_flags()
 dd4hep_use_python_executable()
 
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Find sources
 file(GLOB DDFastCaloSim_SOURCES source/*.cxx)
 
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Create the plugin library
 add_dd4hep_plugin(${PROJECT_NAME} SHARED ${DDFastCaloSim_SOURCES})
 
@@ -44,9 +68,9 @@ add_dd4hep_plugin(${PROJECT_NAME} SHARED ${DDFastCaloSim_SOURCES})
 target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/include)
 
 # Link plugins against Geant4 and DD4hep
-target_link_libraries(${PROJECT_NAME} PUBLIC ${Geant4_LIBRARIES} DD4hep::DDCore DD4hep::DDG4)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${Geant4_LIBRARIES} DD4hep::DDCore DD4hep::DDG4 FastCaloSim::FastCaloSim)
 
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Installation configuration for the plugin library
 install(TARGETS ${PROJECT_NAME}
   EXPORT ${PROJECT_NAME}Targets

--- a/include/DDFastCaloSim/FastCaloSimModel.h
+++ b/include/DDFastCaloSim/FastCaloSimModel.h
@@ -3,6 +3,11 @@
 
 #include <DDG4/Geant4FastSimShowerModel.h>
 
+// -- FastCaloSim includes
+// #include "FastCaloSim/Core/TFCSParametrizationBase.h"
+// #include "FastCaloSim/Extrapolation/FastCaloSimCaloExtrapolation.h"
+// #include "FastCaloSim/Transport/G4CaloTransportTool.h"
+
 class G4FastStep;
 class G4FastTrack;
 class G4ParticleDefinition;
@@ -60,6 +65,14 @@ public:
 
   /// User callback to implement the fast simulation model
   virtual void modelShower(const G4FastTrack& track, G4FastStep& step) override;
+
+private:
+  // // Core FastCaloSim API
+  // TFCSParametrizationBase m_parametrization;
+  // // Geant4 transport tool
+  // G4CaloTransportTool m_transportTool;
+  // // Extrapolation tool
+  // FastCaloSimCaloExtrapolation m_extrapolationTool;
 };
 }  // namespace sim
 }  // namespace dd4hep

--- a/include/DDFastCaloSim/FastCaloSimModel.h
+++ b/include/DDFastCaloSim/FastCaloSimModel.h
@@ -4,9 +4,9 @@
 #include <DDG4/Geant4FastSimShowerModel.h>
 
 // -- FastCaloSim includes
-// #include "FastCaloSim/Core/TFCSParametrizationBase.h"
-// #include "FastCaloSim/Extrapolation/FastCaloSimCaloExtrapolation.h"
-// #include "FastCaloSim/Transport/G4CaloTransportTool.h"
+#include "FastCaloSim/Core/TFCSParametrizationBase.h"
+#include "FastCaloSim/Extrapolation/FastCaloSimCaloExtrapolation.h"
+#include "FastCaloSim/Transport/G4CaloTransportTool.h"
 
 class G4FastStep;
 class G4FastTrack;
@@ -67,12 +67,12 @@ public:
   virtual void modelShower(const G4FastTrack& track, G4FastStep& step) override;
 
 private:
-  // // Core FastCaloSim API
-  // TFCSParametrizationBase m_parametrization;
-  // // Geant4 transport tool
-  // G4CaloTransportTool m_transportTool;
-  // // Extrapolation tool
-  // FastCaloSimCaloExtrapolation m_extrapolationTool;
+  // Core FastCaloSim API
+  TFCSParametrizationBase m_parametrization;
+  // Geant4 transport tool
+  G4CaloTransportTool m_transportTool;
+  // Extrapolation tool
+  FastCaloSimCaloExtrapolation m_extrapolationTool;
 };
 }  // namespace sim
 }  // namespace dd4hep

--- a/source/FastCaloSimModel.cxx
+++ b/source/FastCaloSimModel.cxx
@@ -9,9 +9,15 @@
 #include "G4Event.hh"
 #include "G4EventManager.hh"
 
+// -- FastCaloSim includes
+// #include "FastCaloSim/Core/TFCSTruthState.h"
+
 dd4hep::sim::FastCaloSimModel::FastCaloSimModel(
     dd4hep::sim::Geant4Context* context, const std::string& name)
     : Geant4FastSimShowerModel(context, name)
+// , m_parametrization()
+// , m_transportTool()
+// , m_extrapolationTool()
 {
 }
 bool dd4hep::sim::FastCaloSimModel::check_trigger(const G4FastTrack& track)
@@ -23,6 +29,52 @@ bool dd4hep::sim::FastCaloSimModel::check_trigger(const G4FastTrack& track)
 void dd4hep::sim::FastCaloSimModel::modelShower(const G4FastTrack& aTrack,
                                                 G4FastStep& aStep)
 {
+  // Get Geant4 primary track
+  // const G4Track* track = aTrack.GetPrimaryTrack();
+
+  // Set the FastCaloSim truth state
+  // TFCSTruthState truth;
+  // truth.set_pdgid(track->GetDefinition()->GetPDGEncoding());
+
+  // // Set the kinematics of the FastCaloSim truth state
+  // truth.SetPtEtaPhiM(track->GetMomentum().perp(),
+  //                    track->GetMomentum().eta(),
+  //                    track->GetMomentum().phi(),
+  //                    track->GetDefinition()->GetPDGMass());
+
+  // // Set the vertex of the FastCaloSim truth state
+  // truth.set_vertex(track->GetPosition().x(),
+  //                  track->GetPosition().y(),
+  //                  track->GetPosition().z());
+
+  // printout(INFO,
+  //          "FastSimModel",
+  //          "[DoIt] Received particle with pid=%d",
+  //          truth.pdgid());
+
+  // printout(INFO,
+  //          "FastSimModel",
+  //          "[DoIt] Particle has position x=%.2f y=%.2f z=%.2f eta=%.2f "
+  //          "phi=%.2f r=%.2f ekin=%.2f",
+  //          truth.X(),
+  //          truth.Y(),
+  //          truth.Z(),
+  //          truth.Eta(),
+  //          truth.Phi(),
+  //          truth.Perp(),
+  //          truth.Ekin());
+
+  // printout(INFO,
+  //          "FastSimModel",
+  //          "[DoIt] Particle has momentum px=%.2f py=%.2f pz=%.2f p=%.2f "
+  //          "pt=%.2f eta=%.2f",
+  //          track->GetMomentum().x(),
+  //          track->GetMomentum().y(),
+  //          track->GetMomentum().z(),
+  //          track->GetMomentum().mag(),
+  //          track->GetMomentum().perp(),
+  //          track->GetMomentum().eta());
+
   // Kill particle
   aStep.KillPrimaryTrack();
   aStep.SetPrimaryTrackPathLength(0.0);

--- a/source/FastCaloSimModel.cxx
+++ b/source/FastCaloSimModel.cxx
@@ -77,7 +77,7 @@ void dd4hep::sim::FastCaloSimModel::modelShower(const G4FastTrack& aTrack,
 
   // Kill particle
   aStep.KillPrimaryTrack();
-  aStep.SetPrimaryTrackPathLength(0.0);
+  aStep.ProposePrimaryTrackPathLength(0.0);
   return;
 }
 

--- a/source/FastCaloSimModel.cxx
+++ b/source/FastCaloSimModel.cxx
@@ -10,14 +10,14 @@
 #include "G4EventManager.hh"
 
 // -- FastCaloSim includes
-// #include "FastCaloSim/Core/TFCSTruthState.h"
+#include "FastCaloSim/Core/TFCSTruthState.h"
 
 dd4hep::sim::FastCaloSimModel::FastCaloSimModel(
     dd4hep::sim::Geant4Context* context, const std::string& name)
     : Geant4FastSimShowerModel(context, name)
-// , m_parametrization()
-// , m_transportTool()
-// , m_extrapolationTool()
+    , m_parametrization()
+    , m_transportTool()
+    , m_extrapolationTool()
 {
 }
 bool dd4hep::sim::FastCaloSimModel::check_trigger(const G4FastTrack& track)
@@ -30,50 +30,48 @@ void dd4hep::sim::FastCaloSimModel::modelShower(const G4FastTrack& aTrack,
                                                 G4FastStep& aStep)
 {
   // Get Geant4 primary track
-  // const G4Track* track = aTrack.GetPrimaryTrack();
+  const G4Track* track = aTrack.GetPrimaryTrack();
 
   // Set the FastCaloSim truth state
-  // TFCSTruthState truth;
-  // truth.set_pdgid(track->GetDefinition()->GetPDGEncoding());
+  TFCSTruthState truth;
+  truth.set_pdgid(track->GetDefinition()->GetPDGEncoding());
 
-  // // Set the kinematics of the FastCaloSim truth state
-  // truth.SetPtEtaPhiM(track->GetMomentum().perp(),
-  //                    track->GetMomentum().eta(),
-  //                    track->GetMomentum().phi(),
-  //                    track->GetDefinition()->GetPDGMass());
+  // Set the kinematics of the FastCaloSim truth state
+  truth.SetPtEtaPhiM(track->GetMomentum().perp(),
+                     track->GetMomentum().eta(),
+                     track->GetMomentum().phi(),
+                     track->GetDefinition()->GetPDGMass());
 
-  // // Set the vertex of the FastCaloSim truth state
-  // truth.set_vertex(track->GetPosition().x(),
-  //                  track->GetPosition().y(),
-  //                  track->GetPosition().z());
+  // Set the vertex of the FastCaloSim truth state
+  truth.set_vertex(track->GetPosition().x(),
+                   track->GetPosition().y(),
+                   track->GetPosition().z());
 
-  // printout(INFO,
-  //          "FastSimModel",
-  //          "[DoIt] Received particle with pid=%d",
-  //          truth.pdgid());
+  printout(
+      INFO, "FastSimModel", "Received particle with pid=%d", truth.pdgid());
 
-  // printout(INFO,
-  //          "FastSimModel",
-  //          "[DoIt] Particle has position x=%.2f y=%.2f z=%.2f eta=%.2f "
-  //          "phi=%.2f r=%.2f ekin=%.2f",
-  //          truth.X(),
-  //          truth.Y(),
-  //          truth.Z(),
-  //          truth.Eta(),
-  //          truth.Phi(),
-  //          truth.Perp(),
-  //          truth.Ekin());
+  printout(INFO,
+           "FastSimModel",
+           "Particle has position (%.2f, %.2f, %.2f) eta=%.2f "
+           "phi=%.2f r=%.2f ekin=%.2f",
+           truth.X(),
+           truth.Y(),
+           truth.Z(),
+           truth.Eta(),
+           truth.Phi(),
+           truth.Perp(),
+           truth.Ekin());
 
-  // printout(INFO,
-  //          "FastSimModel",
-  //          "[DoIt] Particle has momentum px=%.2f py=%.2f pz=%.2f p=%.2f "
-  //          "pt=%.2f eta=%.2f",
-  //          track->GetMomentum().x(),
-  //          track->GetMomentum().y(),
-  //          track->GetMomentum().z(),
-  //          track->GetMomentum().mag(),
-  //          track->GetMomentum().perp(),
-  //          track->GetMomentum().eta());
+  printout(INFO,
+           "FastSimModel",
+           "Particle has momentum (%.2f, %.2f, %.2f) p=%.2f "
+           "pt=%.2f eta=%.2f",
+           track->GetMomentum().x(),
+           track->GetMomentum().y(),
+           track->GetMomentum().z(),
+           track->GetMomentum().mag(),
+           track->GetMomentum().perp(),
+           track->GetMomentum().eta());
 
   // Kill particle
   aStep.KillPrimaryTrack();


### PR DESCRIPTION
First basic integration of the [FastCaloSim](https://github.com/fcs-proj/FastCaloSim) library  into DDFastCaloSim. We can get all dependencies automatically from key4hep except for lwtnn, which we take from lcg for now. On the long term, we anyway to get fully rid of [lwtnn](https://github.com/lwtnn/lwtnn) and replace all our machine learning inference with [onnx](https://github.com/onnx/onnx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Integrated FastCaloSim library into the project.
	- Enhanced `modelShower` method to handle Geant4 primary track properties and logging.

- **Chores**
	- Updated project dependencies and build configuration.
	- Added commented sections for potential future development in source files.

- **Documentation**
	- Clarified dependency management in CMakeLists.txt with explanatory comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->