### PR TITLE
Bump key4hep to 2025-01-28

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Use environment variable if set, otherwise use default version
-KEY4HEP_VERSION=${KEY4HEP_VERSION:-"2024-11-28"}
+KEY4HEP_VERSION=${KEY4HEP_VERSION:-"2025-01-28"}
 
 # Setup key4hep environment
 source /cvmfs/sw.hsf.org/key4hep/setup.sh -r "${KEY4HEP_VERSION}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the setup configuration so that users automatically receive the updated default release version when no explicit version is provided. This adjustment ensures that the environment initializes with the most current configuration by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->