### PR TITLE
Fix .so loading in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(DD4hep REQUIRED COMPONENTS DDG4 DDParsers DDCore DDDetectors)
 include(FetchContent)
 # LWTNN is not shipped by DD4hep but a dependency of FastCaloSim
 # We'll give FastCaloSim a hint where to find it
-set(lwtnn_ROOT "/cvmfs/sft.cern.ch/lcg/views/LCG_106/x86_64-el9-gcc13-opt"
+set(lwtnn_ROOT "/cvmfs/sft.cern.ch/lcg/releases/lwtnn/2.13-500c2/x86_64-el9-gcc14-opt/"
   CACHE PATH "Where to find lwtnn" FORCE
 )
 

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -19,11 +19,10 @@ function(add_tests TEST_SOURCES)
         # Propagate the dd4hep environment to tets
         # Preload the DDFastCaloSim library
         set(ENV_VARS
-            "DDFastCaloSim_LIB=${DDFastCaloSim_LIB};"
-            "TEST_BASE_DIR=${TEST_BASE_DIR};"
-            "LD_PRELOAD=${DDFastCaloSim_LIB}:$ENV{LD_PRELOAD};"
-            "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH};"
-            "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}:$ENV{PYTHONPATH};"
+            "TEST_BASE_DIR=${TEST_BASE_DIR}"
+            "DDFastCaloSim_LIB=${DDFastCaloSim_LIB}"
+            "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}"
+            "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}:$ENV{PYTHONPATH}"
         )
 
         set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT "${ENV_VARS}")

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -18,11 +18,14 @@ function(add_tests TEST_SOURCES)
         # Set the test properties
         # Propagate the dd4hep environment to tets
         # Preload the DDFastCaloSim library
-        set_tests_properties(${TEST_NAME} PROPERTIES
-            ENVIRONMENT "DDFastCaloSim_LIB=${DDFastCaloSim_LIB};
-                         TEST_BASE_DIR=${TEST_BASE_DIR};
-                         LD_PRELOAD=${DDFastCaloSim_LIB}:$ENV{LD_PRELOAD};
-                         LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH};
-                         PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}:$ENV{PYTHONPATH};")
+        set(ENV_VARS
+            "DDFastCaloSim_LIB=${DDFastCaloSim_LIB};"
+            "TEST_BASE_DIR=${TEST_BASE_DIR};"
+            "LD_PRELOAD=${DDFastCaloSim_LIB}:$ENV{LD_PRELOAD};"
+            "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH};"
+            "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}:$ENV{PYTHONPATH};"
+        )
+
+        set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT "${ENV_VARS}")
     endforeach()
 endfunction()

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -6,7 +6,7 @@ function(add_tests TEST_SOURCES)
         add_executable(${TEST_NAME} ${TEST_FILE})
 
         # Link the test executable with the GoogleTest and necessary libraries
-        target_link_libraries(${TEST_NAME} PRIVATE gtest gtest_main nlohmann_json::nlohmann_json)
+        target_link_libraries(${TEST_NAME} PRIVATE gtest gtest_main nlohmann_json::nlohmann_json ROOT::Core)
 
         # Add include directories
         target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -15,8 +15,14 @@ function(add_tests TEST_SOURCES)
         add_test(NAME ${TEST_NAME}
             COMMAND ${TEST_NAME})
 
-        # Set the test properties: load the DDFastCaloSim library and set the PYTHONPATH
+        # Set the test properties
+        # Propagate the dd4hep environment to tets
+        # Preload the DDFastCaloSim library
         set_tests_properties(${TEST_NAME} PROPERTIES
-            ENVIRONMENT "LD_PRELOAD=${DDFastCaloSim_LIB};PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}:$ENV{PYTHONPATH};TEST_BASE_DIR=${TEST_BASE_DIR}")
+            ENVIRONMENT "DDFastCaloSim_LIB=${DDFastCaloSim_LIB};
+                         TEST_BASE_DIR=${TEST_BASE_DIR};
+                         LD_PRELOAD=${DDFastCaloSim_LIB}:$ENV{LD_PRELOAD};
+                         LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH};
+                         PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}:$ENV{PYTHONPATH};")
     endforeach()
 endfunction()

--- a/tests/TestHelpers/IOManager.h
+++ b/tests/TestHelpers/IOManager.h
@@ -32,4 +32,13 @@ inline auto ref_dir() -> std::string
   return TEST_REFS_DIR + test_suite_name() + "_" + test_name() + "/";
 }
 
+inline void preload_ddfastcalosim()
+{
+  const char* lib_path = std::getenv("DDFastCaloSim_LIB");
+  if (!lib_path) {
+    FAIL() << "DDFastCaloSim_LIB environment variable is not set";
+  }
+  setenv("LD_PRELOAD", lib_path, 1);
+}
+
 }  // namespace TestHelpers::IOManager

--- a/tests/source/LoadLibTests.cxx
+++ b/tests/source/LoadLibTests.cxx
@@ -1,0 +1,39 @@
+#include <TInterpreter.h>
+#include <TSystem.h>
+#include <gtest/gtest.h>
+
+TEST(LoadLibTests, LoadFastCaloSimClasses)
+{
+  // Get the path to the DDFastCaloSim library (libDDFastCaloSim.so)
+  const char* ddFCSLib = std::getenv("DDFastCaloSim_LIB");
+
+  ASSERT_NE(ddFCSLib, nullptr)
+      << "Environment variable DDFastCaloSimLib is not set!";
+
+  // Load the library with ROOT's gSystem
+  int loadStatus = gSystem->Load(ddFCSLib);
+  if (loadStatus != 0) {
+    std::cerr << "gSystem->Load() failed: " << gSystem->GetErrorStr()
+              << std::endl;
+  }
+
+  // Check if the library was loaded successfully
+  ASSERT_EQ(loadStatus, 0) << "Failed to load the DDFastCaloSim library.";
+
+  // Try to create instances of classes from the FastCaloSim library
+  auto* truthState =
+      reinterpret_cast<void*>(gInterpreter->ProcessLine("new TFCSTruthState;"));
+
+  auto* extrapolState = reinterpret_cast<void*>(
+      gInterpreter->ProcessLine("new TFCSExtrapolationState;"));
+
+  auto* simulState = reinterpret_cast<void*>(
+      gInterpreter->ProcessLine("new TFCSSimulationState;"));
+
+  // Check if the object was successfully created
+  ASSERT_NE(truthState, nullptr) << "Failed to instantiate TFCSTruthState.";
+  ASSERT_NE(extrapolState, nullptr)
+      << "Failed to instantiate TFCSExtrapolationState.";
+  ASSERT_NE(simulState, nullptr)
+      << "Failed to instantiate TFCSSimulationState.";
+}

--- a/tests/source/ODDParametrizationTests.cxx
+++ b/tests/source/ODDParametrizationTests.cxx
@@ -21,7 +21,7 @@ TEST(ODDParametrizationTests, ODDParametrization)
   // Pre-load the DDFastCaloSim library
   /// TODO: instead of this we should be able to just source
   /// thisDDFastCaloSim.sh however something in key4hep is not working properly
-  setenv("LD_PRELOAD", std::getenv("DDFastCaloSim_LIB"), 1);
+  TestHelpers::IOManager::preload_ddfastcalosim();
 
   // Change the current directory to the output directory
   std::filesystem::current_path(output_dir);

--- a/tests/source/ODDParametrizationTests.cxx
+++ b/tests/source/ODDParametrizationTests.cxx
@@ -18,6 +18,11 @@ TEST(ODDParametrizationTests, ODDParametrization)
   // Set test directory as environment variable
   setenv("TEST_WORKING_DIR", output_dir.c_str(), 1);
 
+  // Pre-load the DDFastCaloSim library
+  /// TODO: instead of this we should be able to just source
+  /// thisDDFastCaloSim.sh however something in key4hep is not working properly
+  setenv("LD_PRELOAD", std::getenv("DDFastCaloSim_LIB"), 1);
+
   // Change the current directory to the output directory
   std::filesystem::current_path(output_dir);
 

--- a/tests/source/ODDTransportTests.cxx
+++ b/tests/source/ODDTransportTests.cxx
@@ -22,7 +22,7 @@ TEST(ODDTransportTests, ODDTransport)
   // Pre-load the DDFastCaloSim library
   /// TODO: instead of this we should be able to just source
   /// thisDDFastCaloSim.sh however something in key4hep is not working properly
-  setenv("LD_PRELOAD", std::getenv("DDFastCaloSim_LIB"), 1);
+  TestHelpers::IOManager::preload_ddfastcalosim();
 
   // Change the current directory to the output directory
   std::filesystem::current_path(output_dir);

--- a/tests/source/ODDTransportTests.cxx
+++ b/tests/source/ODDTransportTests.cxx
@@ -19,6 +19,11 @@ TEST(ODDTransportTests, ODDTransport)
   // Set test directory as environment variable
   setenv("TEST_WORKING_DIR", output_dir.c_str(), 1);
 
+  // Pre-load the DDFastCaloSim library
+  /// TODO: instead of this we should be able to just source
+  /// thisDDFastCaloSim.sh however something in key4hep is not working properly
+  setenv("LD_PRELOAD", std::getenv("DDFastCaloSim_LIB"), 1);
+
   // Change the current directory to the output directory
   std::filesystem::current_path(output_dir);
 


### PR DESCRIPTION
This PR 

- fixes a bug where the lwtnn usage from `/cvmfs/sft.cern.ch/lcg/views/LCG_106/x86_64-el9-gcc13-opt` would lead to ROOT version mismatches when loading DDFastCaloSim via ROOT `gSystem->Load(libDDFastCaloSim.so)`. 
- Lwtnn does not have any direct ROOT dependency but it seem that it still picks up something LCG_106 specific which was built with a slight different ROOT version. This is now fixed by using lwtnn from `/cvmfs/sft.cern.ch/lcg/releases/lwtnn/2.13-500c2/x86_64-el9-gcc14-opt/` instead. 
- We were also not propagating the LD_LIBRARY_PATH environment to the tests, which lead to more inconsistencies. 
- To prevent issues in the future, I added a test that interactively loads the DDFastCaloSim library in ROOT and checks whether we can access the underlying FastCaloSim classes.

Note: currently we preload `libDDFastCaloSim.so` with `LD_PRELOAD=libDDFastCaloSim.so` in the tests. The 'right' way of doing so would be to source the `build/thisDDFastCaloSim.sh` script. However, there seems to be some issue in key4hep that prevents the correct loading. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency configuration to use a stable release version for improved build stability.
  - Enhanced the test environment setup by refining library linking and environment variable handling.
- **Tests**
  - Introduced a new test case to verify the proper loading and initialization of key simulation components.
  - Updated existing tests to include pre-loading of the DDFastCaloSim library for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->