### PR TITLE
Add basic hit access in converter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ target_link_libraries(${PROJECT_NAME}
     DD4hep::DDCore
     DD4hep::DDG4
     FastCaloSim::FastCaloSim
+    FastCaloSim::Param
     nlohmann_json::nlohmann_json)
 
 # ----------------------------------------------------------------------------

--- a/cmake/executable.cmake
+++ b/cmake/executable.cmake
@@ -2,26 +2,34 @@
 # Can be used to add executables to the project.
 # Can be executed with: cmake --build . --target run_<NAME>
 
-function(add_exec NAME SOURCES)
-    add_executable("${NAME}" "executables/${NAME}.cxx" ${SOURCES})
+find_package(EDM4HEP 0.99 REQUIRED)
+find_package(podio 1.0 REQUIRED)
+find_package(DD4hep REQUIRED)
 
-    target_include_directories("${NAME}" PRIVATE
-      ${CMAKE_CURRENT_SOURCE_DIR}/include
-    )
+function(add_exec NAME)
+  add_executable("${NAME}" "executables/${NAME}.cxx" ${ARGN})
 
-    target_link_libraries("${NAME}" PRIVATE
-      FastCaloSim::FastCaloSim
-      FastCaloSim::Param
-    )
+  target_include_directories("${NAME}" PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
 
-    target_compile_features("${NAME}" PRIVATE cxx_std_17)
+  target_link_libraries("${NAME}" PUBLIC
+    FastCaloSim::FastCaloSim
+    FastCaloSim::Param
+    DD4hep::DDCore # For bitfield decoder
+    EDM4HEP::edm4hep # For dd4hep reading
+    podio::podio # For dd4hep reading
+    podio::podioRootIO # For dd4hep reading
+  )
 
-    add_custom_target("run_${NAME}"
-      COMMAND "${NAME}"
-      VERBATIM
-    )
+  target_compile_features("${NAME}" PRIVATE cxx_std_17)
 
-    add_dependencies("run_${NAME}" "${NAME}")
+  add_custom_target("run_${NAME}"
+    COMMAND "${NAME}"
+    VERBATIM
+  )
 
-    deactivate_checks(${NAME})
-  endfunction()
+  add_dependencies("run_${NAME}" "${NAME}")
+
+  deactivate_checks(${NAME})
+endfunction()

--- a/cmake/executable.cmake
+++ b/cmake/executable.cmake
@@ -9,11 +9,11 @@ find_package(DD4hep REQUIRED)
 function(add_exec NAME)
   add_executable("${NAME}" "executables/${NAME}.cxx" ${ARGN})
 
-  target_include_directories("${NAME}" PUBLIC
+  target_include_directories("${NAME}" PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   )
 
-  target_link_libraries("${NAME}" PUBLIC
+  target_link_libraries("${NAME}" PRIVATE
     FastCaloSim::FastCaloSim
     FastCaloSim::Param
     DD4hep::DDCore # For bitfield decoder

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -25,6 +25,8 @@ function(add_tests TEST_SOURCES)
         # Preload the DDFastCaloSim library
         set(ENV_VARS
             "TEST_BASE_DIR=${TEST_BASE_DIR}"
+            "FastCaloSim_LIB=${FastCaloSim_LIB}"
+            "FastCaloSimParam_LIB=${FastCaloSimParam_LIB}"
             "DDFastCaloSim_LIB=${DDFastCaloSim_LIB}"
             "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}"
             "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}:$ENV{PYTHONPATH}"

--- a/converter/executables/createParamInput.cxx
+++ b/converter/executables/createParamInput.cxx
@@ -8,7 +8,6 @@
 // ROOT headers
 #include "ROOT/TBufferMerger.hxx"
 #include "ROOT/TTreeProcessorMT.hxx"
-#include "TFile.h"
 #include "TROOT.h"
 #include "TTree.h"
 #include "TTreeReader.h"

--- a/converter/executables/createParamInput.cxx
+++ b/converter/executables/createParamInput.cxx
@@ -3,6 +3,7 @@
 #include "FastCaloSim/Core/TFCSExtrapolationState.h"
 #include "FastCaloSimConverter/ExtrapolationConverter.h"
 #include "FastCaloSimConverter/InputLoader.h"
+#include "FastCaloSimConverter/HitConverter.h"
 
 // ROOT headers
 #include "ROOT/TBufferMerger.hxx"
@@ -57,11 +58,14 @@ auto main(int argc, char* argv[]) -> int
         new TTree("FCS_ParametrizationInput", "FCS_ParametrizationInput");
 
     // Create a thread-local ExtrapolationConverter
-    ExtrapolationConverter converter(n_layers, &reader, outTree);
+    ExtrapolationConverter extrap_converter(n_layers, &reader, outTree);
+    HitConverter hit_converter(dd4hep_input, outTree);
 
     // Process entries in this thread's chunk
     while (reader.Next()) {
-      converter.process_entry();
+      Long64_t entryIndex = reader.GetCurrentEntry();
+      extrap_converter.process_entry();
+      hit_converter.process_entry(entryIndex);
       outTree->Fill();
     }
 

--- a/converter/include/FastCaloSimConverter/HitConverter.h
+++ b/converter/include/FastCaloSimConverter/HitConverter.h
@@ -1,0 +1,52 @@
+#pragma once
+#include <memory>
+#include <mutex>
+
+#include <DDSegmentation/BitFieldCoder.h>
+#include <RtypesCore.h>
+
+#include "FastCaloSimParam/FCS_Cell.h"
+
+class TTree;
+class TTreeReader;
+
+// Forward declarations for EDM4hep
+namespace podio
+{
+class Frame;
+class ROOTReader;
+}  // namespace podio
+
+class HitConverter
+{
+public:
+  /// @brief Creates a converter for EDM4hep hits
+  HitConverter(const std::string& edm4hep_file, TTree* outTree);
+
+  ~HitConverter();
+
+  /// @brief Processes an entry and fills hit data
+  void process_entry(Long64_t entry);
+
+private:
+  /// @brief Creates branches in the output tree
+  void create_branches(TTree* outTree);
+
+  /// @brief Convert EDM4hep hits to FCS hits
+  void convert_hits(const podio::Frame& event);
+
+  // EDM4hep reader (protected by mutex for MT access)
+  std::unique_ptr<podio::ROOTReader> m_reader;
+  std::mutex m_reader_mutex;
+
+  // Output data container
+  std::vector<FCS_hit>* m_hits = nullptr;
+
+  // Output tree
+  TTree* m_outTree = nullptr;
+
+  // Bitfield decoder to access detector information (e.g. layer number)
+  /// TODO: Can we directly access schema information from file?
+  dd4hep::DDSegmentation::BitFieldCoder m_decoder {
+      "system:8,barrel:3,module:4,layer:6,slice:5,x:32:-16,y:-16"};
+};

--- a/converter/source/HitConverter.cxx
+++ b/converter/source/HitConverter.cxx
@@ -1,0 +1,95 @@
+#include "FastCaloSimConverter/HitConverter.h"
+
+#include <TTree.h>
+
+// EDM4hep includes
+#include "edm4hep/SimCalorimeterHitCollection.h"
+#include "podio/Frame.h"
+#include "podio/ROOTReader.h"
+
+HitConverter::HitConverter(const std::string& edm4hep_file, TTree* outTree)
+    : m_outTree(outTree)
+{
+  // Initialize the reader
+  m_reader = std::make_unique<podio::ROOTReader>();
+  m_reader->openFile(edm4hep_file);
+
+  // Initialize the hit vector
+  m_hits = new std::vector<FCS_hit>();
+
+  // Create branches
+  create_branches(outTree);
+}
+
+HitConverter::~HitConverter()
+{
+  delete m_hits;
+}
+
+void HitConverter::create_branches(TTree* outTree)
+{
+  if (!outTree) {
+    std::cerr << "HitConverter::create_branches ERROR: outTree is null!\n";
+    return;
+  }
+
+  // Create branch for the hits
+  outTree->Branch("hits", &m_hits);
+}
+
+void HitConverter::process_entry(Long64_t entry)
+{
+  // Clear previous hits
+  m_hits->clear();
+
+  // Get the EDM4hep event - this needs to be thread-safe
+  podio::Frame event;
+  {
+    std::lock_guard<std::mutex> lock(m_reader_mutex);
+    event = podio::Frame(m_reader->readEntry("events", entry));
+  }
+
+  // Convert the hits
+  convert_hits(event);
+}
+
+void HitConverter::convert_hits(const podio::Frame& event)
+{
+  // Get the calorimeter hits collection
+  auto& schs =
+      event.get<edm4hep::SimCalorimeterHitCollection>("ECalBarrelCollection");
+
+  if (schs.isValid()) {
+    // Process each hit
+    for (const auto& sch : schs) {
+      FCS_hit hit;
+
+      // Fill basic properties
+      hit.identifier = sch.getCellID();
+
+      hit.cell_identifier = sch.getCellID();
+      /// TODO: these layers will not be unique for the whole detector
+      hit.sampling = m_decoder.get(hit.cell_identifier, "layer");
+      hit.hit_energy = sch.getEnergy();
+
+      // Fill position
+      auto pos = sch.getPosition();
+      hit.hit_x = pos.x;
+      hit.hit_y = pos.y;
+      hit.hit_z = pos.z;
+
+      // Time from first contribution if available
+      /// @TODO: is this the time we want?
+      hit.hit_time = 0;
+      if (sch.contributions_size() > 0) {
+        auto contrib = sch.getContributions(0);
+        hit.hit_time = contrib.getTime();
+      }
+
+      // Add to hits vector
+      m_hits->push_back(hit);
+    }
+  } else {
+    std::cerr << "SimCalorimeterHits collection not found or invalid\n";
+  }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,9 +35,15 @@ FetchContent_MakeAvailable(googletest)
 
 enable_testing()
 
-# Set the DDFastCaloSim library
+# ---- FastCaloSim Libraries ----
+set(FastCaloSim_LIB "${CMAKE_BINARY_DIR}/_deps/fastcalosim-build/libFastCaloSim.so")
+set(FastCaloSimParam_LIB "${CMAKE_BINARY_DIR}/_deps/fastcalosim-build/param/libFastCaloSim_Param.so")
+
+# ---- DDFastCaloSim Library ----
 set(DDFastCaloSim_LIB "${CMAKE_BINARY_DIR}/libDDFastCaloSim.so")
 
+message(STATUS "Using FastCaloSim_LIB = ${FastCaloSim_LIB}")
+message(STATUS "Using FastCaloSimParam_LIB = ${FastCaloSimParam_LIB}")
 message(STATUS "Using DDFastCaloSim_LIB = ${DDFastCaloSim_LIB}")
 
 # ---- Tests ----

--- a/tests/source/ParamConverterTests.cxx
+++ b/tests/source/ParamConverterTests.cxx
@@ -2,20 +2,33 @@
 #include <filesystem>
 #include <iostream>
 #include <string>
-#include <vector>
 
 #include <TBranch.h>
 #include <TFile.h>
+#include <TInterpreter.h>
+#include <TSystem.h>
 #include <TTree.h>
 #include <gtest/gtest.h>
 
-#include "FastCaloSim/Core/TFCSExtrapolationState.h"
 #include "TestConfig/ParamConverterTestsConfig.h"
 #include "TestHelpers/IOManager.h"
 #include "TestHelpers/LogComparer.h"
 
 TEST(ParamConverterTests, ParamConverterTest)
 {
+  // Let ROOT load the Param dictionary
+  const char* ddFCSLib = std::getenv("FastCaloSimParam_LIB");
+
+  ASSERT_NE(ddFCSLib, nullptr)
+      << "Environment variable FastCaloSimParamLib is not set!";
+
+  // Load the library with ROOT's gSystem
+  int loadStatus = gSystem->Load(ddFCSLib);
+  if (loadStatus != 0) {
+    std::cerr << "gSystem->Load() failed: " << gSystem->GetErrorStr()
+              << std::endl;
+  }
+
   // Create the output directory for the test
   const std::string test_output_dir =
       TestHelpers::IOManager::create_test_output_dir();


### PR DESCRIPTION
Add a basic HitConverter class to the converter that can read hits from dd4hep output in EDM4hep format. The current implementation is preliminary and has various caveats:

- Only implemented for ECalBarrelCollection
- Assumes that layer number for EDM are unique for whole detector (which is not the case has barrel and endcap layers can have identical sampling id's)
- Hard-codes bit-field decoder schema, which should be automatically extracted in the future
- Takes hit timing from first MC step contribution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced hit data conversion now processes event entries with improved data handling.
  - Updated the build configuration to integrate additional external libraries, broadening functionality.

- **Tests**
  - Strengthened the test suite with new environment validations and dynamic library loading checks for improved reliability.

- **Chores**
  - Refined build and dependency management for smoother integration and overall performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->